### PR TITLE
Fix evre events docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# SINAP Timing Epics IOC
+
+> LNLS - Brazilian Synchrotron Light Laboratory  
+> CNPEM - Brazilian Center for Research in Energy and Materials  
+
+## Running the IOC
+
+See the repository registry to find the image. The image uses [ProcServ](https://linux.die.net/man/1/procserv) to run the IOC with parameters:
+
+- `i`: Configure IP address to connect to device
+- `t`: Configure procServ telnet port
+- `P`: Configure value of \$(P) macro
+- `R`: Configure value of \$(R) macro
+- `p`: Configure IP port number to connect to device
+- `d`: Configure Sinap Timing device type [EVG<number>|EVR<number>|EVE<number>|FOUT<number>]
+- `l`: Configure High-level events link to load at EVG
+
+E.g.: 
+
+`docker run -d --name EVE01 -it -v /ioc-autosave/EVE01:/opt/epics/startup/ioc/sinap-timing-epics-ioc/iocBoot/ioctiming/autosave --net host ghcr.io/lnls-dig/sinap-timing-epics-ioc -i 192.168.0.1 -t 1000 -p 1001 -d EVE01 -P TEST: -R EVE01:`
+
+### How to build docker image
+
+Run `docker compose` from docker directory saving COMMIT_ID as environemnt variable:
+
+`COMMIT_ID=$(git rev-parse --short HEAD) docker compose build --build-arg .env`

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -21,19 +21,17 @@
 
 TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 
-SUPPORT=/opt/epics/synApps-lnls-R1-1-2/support
-
 # If using the sequencer, point SNCSEQ at its top directory:
-SNCSEQ=$(SUPPORT)/seq-2-2-6
+SNCSEQ=/opt/epics-R3.15.6/modules/sequencer-2-2-R2-2-6
 
 # EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/opt/epics/base
+EPICS_BASE=/opt/epics-R3.15.6/base
 
 # Set RULES here if you want to take build rules from somewhere
 # other than EPICS_BASE:
 #RULES=/path/to/epics/support/module/rules/x-y
 
-ASYN=$(SUPPORT)/asyn-R4-33
-STREAM=$(SUPPORT)/stream-R2-8-8/StreamDevice-2-8-8
-CALC=$(SUPPORT)/calc-R3-7-1
-AUTOSAVE=$(SUPPORT)/autosave-R5-9
+ASYN=/opt/epics-R3.15.6/modules/asyn-R4-33
+STREAM=/opt/epics-R3.15.6/modules/StreamDevice-2.8.8
+CALC=/opt/epics-R3.15.6/modules/calc-R3-7-1
+AUTOSAVE=/opt/epics-R3.15.6/modules/autosave-R5-9

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,0 +1,2 @@
+*/O.*/
+iocBoot/ioctiming/envPaths

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,5 @@
+BASE_VERSION=3.15.6
+#COMMIT_ID=$(git rev-parse --short HEAD)
+DEBIAN_VERSION=debian:11.6-slim
+IOC_GROUP=lnls-dig
+IOC_REPO=sinap-timing-epics-ioc

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,45 @@
+#Start from image
+ARG DEBIAN_VERSION
+FROM ${DEBIAN_VERSION}
+
+#Define Environment Variables
+ARG BASE_VERSION
+ARG IOC_REPO
+ENV BOOT_DIR ioctiming
+
+#Install first dependencies
+RUN apt update && apt install -y \
+    build-essential \
+    procserv \
+    wget \
+    python3 && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+#Define Work directory as ioc repo
+WORKDIR /opt/epics/${IOC_REPO}
+
+#Install epics base and modules
+COPY ./docker/epics_setup.sh ./
+RUN ./epics_setup.sh ${BASE_VERSION} && \
+    rm ./epics_setup.sh
+
+#Copy ioc files and compile
+COPY ./Makefile ./
+COPY ./configure ./configure
+COPY ./timingApp ./timingApp
+COPY ./iocBoot ./iocBoot
+COPY ./install ./install
+RUN make install clean
+
+#Remove unused packages
+RUN apt update && \
+    apt remove -y \
+    build-essential \ 
+    wget && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set work directory to ioc boot and set ProcServ as entrypoint
+WORKDIR /opt/epics/startup/ioc/${IOC_REPO}/iocBoot/${BOOT_DIR}
+ENTRYPOINT ["./runProcServ.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  ioc:
+    image: ghcr.io/${IOC_GROUP}/${IOC_REPO}:${COMMIT_ID}
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+      labels:
+        org.opencontainers.image.revision: ${COMMIT_ID}
+        org.opencontainers.image.source: https://github.com/${IOC_GROUP}/${IOC_REPO}
+        org.opencontainers.image.description: "SINAP Timing EPICS IOC container"
+      args:
+        BASE_VERSION: ${BASE_VERSION}
+        COMMIT_ID: ${COMMIT_ID}
+        DEBIAN_VERSION: ${DEBIAN_VERSION}
+        IOC_GROUP: ${IOC_GROUP}
+        IOC_REPO: ${IOC_REPO}

--- a/docker/epics_setup.sh
+++ b/docker/epics_setup.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+if [ $# -eq 0 ]
+then
+    export BASE="3.15.6"
+else
+    export BASE=$1
+fi
+
+# Versions to be installed
+export ASYN="4-33"
+export SEQ="2-2-6"
+export STREAM="2.8.8"
+export CALC="3-7-1"
+export AUTOSAVE="5-9"
+
+#Run apt update
+apt update
+
+# EPICS Base
+apt install -y libreadline-dev
+cd /opt
+mkdir epics-R${BASE}
+cd epics-R${BASE}
+wget https://epics-controls.org/download/base/base-${BASE}.tar.gz
+tar -xvzf base-${BASE}.tar.gz
+rm base-${BASE}.tar.gz
+mv base-${BASE} base
+cd base
+make install clean
+cd /opt/epics-R${BASE}
+mkdir modules
+
+# asynDriver
+cd /opt/epics-R${BASE}/modules
+wget https://github.com/epics-modules/asyn/archive/refs/tags/R${ASYN}.tar.gz
+tar -xvzf R${ASYN}.tar.gz
+rm R${ASYN}.tar.gz
+cd asyn-R${ASYN}
+sed -i -e "s|^.*EPICS_BASE=.*$|EPICS_BASE=/opt/epics-R${BASE}/base|" \
+       -e "s|^.*SNCSEQ=.*$|#SNCSEQ=|" \
+       -e "s|^.*CALC=.*$|#CALC=|" \
+       -e "s|^.*IPAC=.*$|#IPAC=|" \
+       -e "s|^.*SUPPORT=.*$|#SUPPORT=|" \
+       configure/RELEASE
+make install clean
+
+# Sequencer
+apt install -y re2c
+cd /opt/epics-R${BASE}/modules
+wget https://github.com/icshwi/sequencer-2-2/archive/refs/tags/R${SEQ}.tar.gz
+tar -xvzf R${SEQ}.tar.gz
+rm R${SEQ}.tar.gz
+cd /opt/epics-R${BASE}/modules/sequencer-2-2-R${SEQ}
+sed -i -e "s|^.*EPICS_BASE=.*$|EPICS_BASE=/opt/epics-R${BASE}/base|" configure/RELEASE
+make install clean
+
+#Calc
+cd /opt/epics-R${BASE}/modules
+wget  https://github.com/epics-modules/calc/archive/R${CALC}.tar.gz
+tar -xvzf R${CALC}.tar.gz
+rm R${CALC}.tar.gz
+cd calc-R${CALC}
+sed -i -e "s|^.*SUPPORT=.*$|#SUPPORT=|" \
+       -e "8s/^/#/" \
+       -e "s|^.*SSCAN=.*$|#SSCAN=|" \
+       -e "s|^.*EPICS_BASE=.*$|EPICS_BASE=/opt/epics-R${BASE}/base|" \
+       configure/RELEASE
+make install clean
+
+#Stream
+apt install -y libpcre3 libpcre3-dev
+cd /opt/epics-R${BASE}/modules
+wget  https://github.com/paulscherrerinstitute/StreamDevice/archive/${STREAM}.tar.gz
+tar -xvzf ${STREAM}.tar.gz
+rm ${STREAM}.tar.gz
+cd StreamDevice-${STREAM}
+sed -i -e "s|^.*EPICS_BASE=.*$|EPICS_BASE=/opt/epics-R${BASE}/base|" \
+       -e "s|^.*ASYN=.*$|ASYN=/opt/epics-R${BASE}/modules/asyn-R${ASYN}|" \
+       -e "s|^.*CALC=.*$|CALC=/opt/epics-R${BASE}/modules/calc-R${CALC}|" \
+       -e "23cPCRE_INCLUDE=/usr/include/pcre" \
+       -e "24cPCRE_LIB=/usr/lib64" \
+       configure/RELEASE
+make install clean
+
+# Autosave
+cd /opt/epics-R${BASE}/modules
+wget https://github.com/epics-modules/autosave/archive/R${AUTOSAVE}.tar.gz
+tar -xvzf R${AUTOSAVE}.tar.gz
+rm R${AUTOSAVE}.tar.gz
+cd autosave-R${AUTOSAVE}
+sed -i -e "s|^.*EPICS_BASE=.*$|EPICS_BASE=/opt/epics-R${BASE}/base|" \
+       -e "s|^.*SUPPORT=.*$|#SUPPORT=|" \
+       configure/RELEASE
+make install clean
+
+#Clean apt to reduce layer size
+apt clean
+rm -rf /var/lib/apt/lists/*

--- a/iocBoot/ioctiming/runProcServ.sh
+++ b/iocBoot/ioctiming/runProcServ.sh
@@ -20,7 +20,7 @@ set -u
 
 # Run run*.sh scripts with procServ
 if [ "${UNIX_SOCKET}" ]; then
-    /usr/local/bin/procServ -f -n TIMING_${DEVICE_TYPE} -i ^C^D unix:./procserv.sock ./runGenericModule.sh "$@"
+    /usr/bin/procServ -f -n TIMING_${DEVICE_TYPE} -i ^C^D unix:./procserv.sock ./runGenericModule.sh "$@"
 else
-    /usr/local/bin/procServ -f -n TIMING_${DEVICE_TYPE} -i ^C^D ${DEVICE_TELNET_PORT} ./runGenericModule.sh "$@"
+    /usr/bin/procServ -f -n TIMING_${DEVICE_TYPE} -i ^C^D ${DEVICE_TELNET_PORT} ./runGenericModule.sh "$@"
 fi

--- a/iocBoot/ioctiming/stEVG.cmd
+++ b/iocBoot/ioctiming/stEVG.cmd
@@ -33,14 +33,14 @@ dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=5, PORT=${PORT}, 
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=6, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=7, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=0, PORT=${PORT}, ADDR=0, TIMEOUT=2")
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=1, PORT=${PORT}, ADDR=0, TIMEOUT=2")
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=2, PORT=${PORT}, ADDR=0, TIMEOUT=2")
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=3, PORT=${PORT}, ADDR=0, TIMEOUT=2")
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=4, PORT=${PORT}, ADDR=0, TIMEOUT=2")
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=5, PORT=${PORT}, ADDR=0, TIMEOUT=2")
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=6, PORT=${PORT}, ADDR=0, TIMEOUT=2")
-dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=7, PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=0, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=1, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=2, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=3, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=4, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=5, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=6, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
+dbLoadRecords("${TOP}/db/evg_clk.db", "P=${P}, R=${R}, num=7, desc='Undefined', PORT=${PORT}, ADDR=0, TIMEOUT=2")
 
 dbLoadRecords "${TOP}/db/Events.db", "P=${P}, R=${R}, num=0,   desc='Undefined', code='01', time=100, mode=0, transm=0, PORT=${PORT}, ADDR=0, TIMEOUT=2, EVT_DELAY=${EVT_DELAY}"
 dbLoadRecords "${TOP}/db/Events.db", "P=${P}, R=${R}, num=1,   desc='Undefined', code='02', time=101, mode=0, transm=0, PORT=${PORT}, ADDR=0, TIMEOUT=2, EVT_DELAY=${EVT_DELAY}"

--- a/timingApp/Db/autosave_evg.req
+++ b/timingApp/Db/autosave_evg.req
@@ -9,6 +9,14 @@ $(P)$(R)Clk4MuxEnbl-Sel
 $(P)$(R)Clk5MuxEnbl-Sel
 $(P)$(R)Clk6MuxEnbl-Sel
 $(P)$(R)Clk7MuxEnbl-Sel
+$(P)$(R)Clk0Desc-SP
+$(P)$(R)Clk1Desc-SP
+$(P)$(R)Clk2Desc-SP
+$(P)$(R)Clk3Desc-SP
+$(P)$(R)Clk4Desc-SP
+$(P)$(R)Clk5Desc-SP
+$(P)$(R)Clk6Desc-SP
+$(P)$(R)Clk7Desc-SP
 $(P)$(R)DI0Calc
 $(P)$(R)DI1Calc
 $(P)$(R)DIEnbl0-Sel
@@ -18,6 +26,7 @@ $(P)$(R)DILog1-Sel
 $(P)$(R)DIPol0-Sel
 $(P)$(R)DIPol1-Sel
 $(P)$(R)DevEnbl-Sel
+$(P)$(R)RxEnbl-SP
 $(P)$(R)Evt01DelayType-Sel
 $(P)$(R)Evt02DelayType-Sel
 $(P)$(R)Evt03DelayType-Sel

--- a/timingApp/Db/autosave_fout.req
+++ b/timingApp/Db/autosave_fout.req
@@ -1,2 +1,3 @@
 # Control and Status
 $(P)$(R)DevEnbl-Sel.VAL
+$(P)$(R)RxEnbl-SP

--- a/timingApp/Db/evg.db
+++ b/timingApp/Db/evg.db
@@ -1236,6 +1236,8 @@ record(ao, "$(P)$(R)RFDiv-SP"){
   field(DTYP, "stream")
   field(DRVH, "4")
   field(DRVL, "4")
+  field(HOPR, "4")
+  field(LOPR, "4")
   field(VAL, "4")
   field(AOFF, "1")
   field(PREC, "0")

--- a/timingApp/Db/evg_clk.db
+++ b/timingApp/Db/evg_clk.db
@@ -89,6 +89,19 @@ record(ao, "$(P)$(R)Clk$(num)MuxDiv-SP"){
   field(OUT, "@timing.proto evg_mux_set($(P),$(R),$(num)) $(PORT)")
 }
 
+record(stringout, "$(P)$(R)Clk$(num)Desc-SP"){
+  field(PINI, "1")
+  field(VAL, "$(desc)")
+  field(DESC, "Description of the Clock Output")
+  field(FLNK, "$(P)$(R)Clk$(num)Desc-RB")
+}
+
+record(stringin, "$(P)$(R)Clk$(num)Desc-RB"){
+  field(VAL, "$(desc)")
+  field(DESC, "Description of the Clock Output Readback")
+  field(INP, "$(P)$(R)Clk$(num)Desc-SP")
+}
+
 record(calc, "$(P)$(R)cmd_mux_get$(num)") {
   field(ASG, "Reserved")
   field(DESC, "Command code to read Mux$(num) register")

--- a/timingApp/Db/evre_otp.db
+++ b/timingApp/Db/evre_otp.db
@@ -3,7 +3,7 @@
 
 record(longout, "$(P)$(R)OTP$(num)Evt-SP") {
   field(DESC, "OTP$(num) event code")
-  field(DRVH, "63")
+  field(DRVH, "255")
   field(DRVL, "0")
   field(DTYP, "stream")
   field(OUT, "@timing.proto evre_otp_set($(P),$(R),$(num)) $(PORT)")


### PR DESCRIPTION
Pull Request modifications:
- Change OTP Events limit to 255 (issue #7 )
- Create a docker dir to build image using docker compose, merging repository [docker-sinap-timing-epics-ioc](https://github.com/lnls-sirius/docker-sinap-timing-epics-ioc/) to ioc rep
- Add RxEnable to autosave (Fanout and EVG)
- Add Desc string records to EVG clocks (SP and RB)
- Limit RFDiv record display values