### PR TITLE
timingApp: implement new version string.

### DIFF
--- a/iocBoot/ioctiming/stEVE.cmd
+++ b/iocBoot/ioctiming/stEVE.cmd
@@ -21,6 +21,8 @@ drvAsynIPPortConfigure ("${PORT}", "${IPADDR}:${IPPORT} udp",0,0,0)
 ## Load record instances
 dbLoadRecords("${TOP}/db/eve.db", "P=${P}, R=${R}, IPADDR=${IPADDR}, IPPORT=${IPPORT}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 
+dbLoadRecords("${TOP}/db/fw_version.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
+
 dbLoadRecords("${TOP}/db/evre_otp.db", "P=${P}, R=${R}, num=00, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evre_otp.db", "P=${P}, R=${R}, num=01, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evre_otp.db", "P=${P}, R=${R}, num=02, PORT=${PORT}, ADDR=0, TIMEOUT=2")

--- a/iocBoot/ioctiming/stEVG.cmd
+++ b/iocBoot/ioctiming/stEVG.cmd
@@ -24,6 +24,8 @@ drvAsynIPPortConfigure ("${PORT}", "${IPADDR}:${IPPORT} udp",0,0,0)
 dbLoadRecords("${TOP}/db/evg.db", "P=${P}, R=${R}, IPADDR=${IPADDR}, IPPORT=${IPPORT}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords "${TOP}/db/SeqRAM.db", "P=${P}, R=${R}"
 
+dbLoadRecords("${TOP}/db/fw_version.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
+
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=0, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=1, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=2, PORT=${PORT}, ADDR=0, TIMEOUT=2")

--- a/iocBoot/ioctiming/stEVR.cmd
+++ b/iocBoot/ioctiming/stEVR.cmd
@@ -21,6 +21,8 @@ drvAsynIPPortConfigure ("${PORT}", "${IPADDR}:${IPPORT} udp",0,0,0)
 ## Load record instances
 dbLoadRecords("${TOP}/db/evr.db", "P=${P}, R=${R}, IPADDR=${IPADDR}, IPPORT=${IPPORT}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 
+dbLoadRecords("${TOP}/db/fw_version.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
+
 dbLoadRecords("${TOP}/db/evre_otp.db", "P=${P}, R=${R}, num=00, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evre_otp.db", "P=${P}, R=${R}, num=01, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evre_otp.db", "P=${P}, R=${R}, num=02, PORT=${PORT}, ADDR=0, TIMEOUT=2")

--- a/iocBoot/ioctiming/stFOUT.cmd
+++ b/iocBoot/ioctiming/stFOUT.cmd
@@ -21,6 +21,8 @@ drvAsynIPPortConfigure ("${PORT}", "${IPADDR}:${IPPORT} udp",0,0,0)
 ## Load record instances
 dbLoadRecords("${TOP}/db/fout.db", "P=${P}, R=${R}, IPADDR=${IPADDR}, IPPORT=${IPPORT}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 
+dbLoadRecords("${TOP}/db/fw_version.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, TIMEOUT=2")
+
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=0, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=1, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=2, PORT=${PORT}, ADDR=0, TIMEOUT=2")

--- a/timingApp/Db/Makefile
+++ b/timingApp/Db/Makefile
@@ -22,6 +22,7 @@ DB += fout.db
 DB += Events.db
 DB += HLEvents.db
 DB += SeqRAM.db
+DB += fw_version.db
 
 DB += $(AUTOSAVE)/asApp/Db/save_restoreStatus.db
 

--- a/timingApp/Db/eve.db
+++ b/timingApp/Db/eve.db
@@ -909,36 +909,6 @@ record(longout, "$(P)$(R)cmd_diginp_get2") {
 }
 
 ########################################################################
-# Firmware Version [62]
-
-record(longin, "$(P)$(R)FrmVersionA-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionB-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionC-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(calcout, "$(P)$(R)cmd_frmvrs_get"){
-  field(ASG, "Reserved")
-  field(DESC, "Firmware version read command code")
-  field(VAL, "0xBE")
-}
-
-########################################################################
 # Configuration Register [63]
 
 record(longin, "$(P)$(R)Alive-Mon") {

--- a/timingApp/Db/evg.db
+++ b/timingApp/Db/evg.db
@@ -1142,36 +1142,6 @@ record(mbbiDirect, "$(P)$(R)IntlkEvtStatus-Mon") {
 }
 
 ########################################################################
-# Firmware Version [62]
-
-record(longin, "$(P)$(R)FrmVersionA-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "EVO firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionB-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "EVO firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionC-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "EVO firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(calcout, "$(P)$(R)cmd_frmvrs_get"){
-  field(ASG, "Reserved")
-  field(DESC, "Firmware version read command code")
-  field(VAL, "0xBE")
-}
-
-########################################################################
 # Configuration Register [63]
 
 record(longin, "$(P)$(R)Alive-Mon") {

--- a/timingApp/Db/evr.db
+++ b/timingApp/Db/evr.db
@@ -875,36 +875,6 @@ record(longout, "$(P)$(R)cmd_diginp_get2") {
 }
 
 ########################################################################
-# Firmware Version [62]
-
-record(longin, "$(P)$(R)FrmVersionA-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionB-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionC-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(calcout, "$(P)$(R)cmd_frmvrs_get"){
-  field(ASG, "Reserved")
-  field(DESC, "Firmware version read command code")
-  field(VAL, "0xBE")
-}
-
-########################################################################
 # Configuration Register [63]
 
 record(longin, "$(P)$(R)Alive-Mon") {

--- a/timingApp/Db/fout.db
+++ b/timingApp/Db/fout.db
@@ -93,36 +93,6 @@ record(longout, "$(P)$(R)cmd_ctrl_set") {
 }
 
 ########################################################################
-# Firmware Version [62]
-
-record(longin, "$(P)$(R)FrmVersionA-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "EVO firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionB-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "EVO firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(longin, "$(P)$(R)FrmVersionC-Cte"){
-  #field(ASG, "Reserved")
-  field(DESC, "EVO firmware version")
-  field(DTYP, "stream")
-  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
-}
-
-record(calcout, "$(P)$(R)cmd_frmvrs_get"){
-  field(ASG, "Reserved")
-  field(DESC, "Firmware version read command code")
-  field(VAL, "0xBE")
-}
-
-########################################################################
 # Configuration Register [63]
 
 record(longin, "$(P)$(R)Alive-Mon") {

--- a/timingApp/Db/fw_version.db
+++ b/timingApp/Db/fw_version.db
@@ -1,0 +1,50 @@
+########################################################################
+# Firmware Version [62]
+
+record(longin, "$(P)$(R)FrmVersionA-Cte"){
+  #field(ASG, "Reserved")
+  field(DESC, "firmware version")
+  field(DTYP, "stream")
+  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
+}
+
+record(longin, "$(P)$(R)FrmVersionB-Cte"){
+  #field(ASG, "Reserved")
+  field(DESC, "firmware version")
+  field(DTYP, "stream")
+  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
+}
+
+record(longin, "$(P)$(R)FrmVersionC-Cte"){
+  #field(ASG, "Reserved")
+  field(DESC, "firmware version")
+  field(DTYP, "stream")
+  field(INP, "@timing.proto frmvrs_get($(P),$(R)) $(PORT)")
+}
+
+record(calcout, "$(P)$(R)cmd_frmvrs_get"){
+  field(ASG, "Reserved")
+  field(DESC, "Firmware version read command code")
+  field(VAL, "0xBE")
+}
+
+record(scalcout, "$(P)$(R)FrmVersionAStr-Cte") {
+  field(INPA, "$(P)$(R)FrmVersionA-Cte CP")
+  field(CALC, "PRINTF(\"%08x\",A)")
+}
+record(scalcout, "$(P)$(R)FrmVersionBStr-Cte") {
+  field(INPA, "$(P)$(R)FrmVersionB-Cte CP")
+  field(CALC, "PRINTF(\"%08x\",A)")
+}
+record(scalcout, "$(P)$(R)FrmVersionCStr-Cte") {
+  field(INPA, "$(P)$(R)FrmVersionC-Cte CP")
+  field(CALC, "PRINTF(\"%08x\",A)")
+}
+
+record(scalcout, "$(P)$(R)FwVersion-Cte"){
+  field(INAA, "$(P)$(R)FrmVersionAStr-Cte.SVAL CP")
+  field(INBB, "$(P)$(R)FrmVersionBStr-Cte.SVAL CP")
+  field(INCC, "$(P)$(R)FrmVersionCStr-Cte.SVAL CP")
+  field(CALC, "AA+BB+CC")
+  field(PINI, YES)
+}

--- a/timingApp/Db/timing.proto
+++ b/timingApp/Db/timing.proto
@@ -792,8 +792,6 @@ evg_async_set {
 # Firmware version register EVG, Fanout, EVR & EVE [62]
 
 frmvrs_get{
-    out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_frmvrs_get)r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
-    in "\x02%*04r\x00\x0D\xFE%(\$1\$2FrmVersionA-Cte)04r%(\$1\$2FrmVersionB-Cte)04r%(\$1\$2FrmVersionC-Cte)04r";
     @init{
       out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_frmvrs_get)r\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00";
       in "\x02%*04r\x00\x0D\xFE%(\$1\$2FrmVersionA-Cte)04r%(\$1\$2FrmVersionB-Cte)04r%(\$1\$2FrmVersionC-Cte)04r";


### PR DESCRIPTION
The 36 character limit in CALC made it necessary to define 3 intermediary records.

Fixes #14 

@anacso17 it would be nice to replace the version in the interface with the single `FwVersion-Cte.SVAL` PV