### PR TITLE
docker: fix EVG alias list creation.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
         REPONAME: sinap-timing-epics-ioc
         RUNDIR: /opt/sinap-timing-epics-ioc/iocBoot/ioctiming
         ENTRYPOINT: ./runProcServ.sh
-        RUNTIME_PACKAGES: python3
+        RUNTIME_PACKAGES: python3 ca-certificates


### PR DESCRIPTION
ca-certificates is necessary to access the content on github.

Fixes #21 