### PR TITLE
docker: use python minimal to reduce image size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,4 +13,4 @@ services:
         REPONAME: sinap-timing-epics-ioc
         RUNDIR: /opt/sinap-timing-epics-ioc/iocBoot/ioctiming
         ENTRYPOINT: ./runProcServ.sh
-        RUNTIME_PACKAGES: python3 ca-certificates
+        RUNTIME_PACKAGES: python3-minimal libpython3-stdlib ca-certificates


### PR DESCRIPTION
This PR reduces 4MB image size:
```
REPOSITORY                                 TAG       IMAGE ID       CREATED          SIZE
ghcr.io/lnls-dig/sinap-timing-epics-ioc    d92a19d   783a458f0e96   2 minutes ago    161MB
ghcr.io/lnls-dig/sinap-timing-epics-ioc    a173675   e4b94402e798   31 minutes ago   165MB
```

- libpython3-stdlib needs to be installed to use urllib