### PR TITLE
timingApp: remove unused SCAN rates.

### DIFF
--- a/timingApp/src/menuScan.dbd
+++ b/timingApp/src/menuScan.dbd
@@ -9,10 +9,5 @@ menu(menuScan) {
 	choice(menuScan_5_second,".5 second")
 	choice(menuScan_2_second,".2 second")
 	choice(menuScan_1_second,".1 second")
-	choice(menuScan_05_second,".05 second")
-	choice(menuScan_02_second,".02 second")
 	choice(menuScan_01_second,".01 second")
-	choice(menuScan_005_second,".005 second")
-	choice(menuScan_002_second,".002 second")
-	choice(menuScan_001_second,".001 second")
 }


### PR DESCRIPTION
Even though they aren't used, the threads for them are still created, and can take up some amount of processing resources (as demonstrated by overrun messages printed by them when the host is busy).