### PR TITLE
timingApp: limit how many bits of RxEnbl can be 1.

### DIFF
--- a/iocBoot/ioctiming/stEVG.cmd
+++ b/iocBoot/ioctiming/stEVG.cmd
@@ -32,6 +32,8 @@ dbLoadRecords("${TOP}/db/event_log.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, T
 
 dbLoadRecords("${TOP}/db/rx_locked.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, TIMEOUT=2, DEVICE=evg")
 
+dbLoadRecords("${TOP}/db/evgfout_rxenbl.db", "P=${P}, R=${R}")
+
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=0, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=1, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=2, PORT=${PORT}, ADDR=0, TIMEOUT=2")

--- a/iocBoot/ioctiming/stFOUT.cmd
+++ b/iocBoot/ioctiming/stFOUT.cmd
@@ -28,6 +28,8 @@ dbLoadRecords("${TOP}/db/fw_version.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, 
 
 dbLoadRecords("${TOP}/db/rx_locked.db", "P=${P}, R=${R}, PORT=${PORT}, ADDR=0, TIMEOUT=2, DEVICE=fout")
 
+dbLoadRecords("${TOP}/db/evgfout_rxenbl.db", "P=${P}, R=${R}")
+
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=0, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=1, PORT=${PORT}, ADDR=0, TIMEOUT=2")
 dbLoadRecords("${TOP}/db/evgfout_out.db", "P=${P}, R=${R}, num=2, PORT=${PORT}, ADDR=0, TIMEOUT=2")

--- a/timingApp/Db/Makefile
+++ b/timingApp/Db/Makefile
@@ -13,7 +13,7 @@ include $(TOP)/configure/CONFIG
 DB += evre_otp.db
 DB += evre_otp_scan.db
 DB += evre_out.db
-DB += evgfout_out.db
+DB += evgfout_out.db evgfout_rxenbl.db
 DB += evg_clk.db
 DB += eve.db
 DB += evg.db

--- a/timingApp/Db/evg.db
+++ b/timingApp/Db/evg.db
@@ -40,12 +40,12 @@ record(stringout, "$(P)$(R)IPPort-Mon"){
 ########################################################################
 # Control and Status Register [0]
 
-record(mbboDirect, "$(P)$(R)RxEnbl-SP") {
-  field(DESC, "Each bit sets Rx OUT status")
+record(mbboDirect, "$(P)$(R)RxEnblHw-SP") {
+  field(DESC, "RxEnbl actually written to hw.")
   field(NOBT, "8")
   field(DTYP, "stream")
   field(OUT, "@timing.proto evg_ctrl_set($(P),$(R)) $(PORT)")
-  field(ASG, "Interlock")
+  field(ASG, "Reserved")
 }
 
 record(mbbiDirect, "$(P)$(R)RxEnbl-RB") {

--- a/timingApp/Db/evgfout_out.db
+++ b/timingApp/Db/evgfout_out.db
@@ -53,4 +53,3 @@ record(calcout, "$(P)$(R)cmd_out_get$(num)") {
   field(CALC, "A + B")
   field(OUT, "@timing.proto evgfout_out_get($(P),$(R),$(num)) $(PORT)")
 }
-

--- a/timingApp/Db/evgfout_rxenbl.db
+++ b/timingApp/Db/evgfout_rxenbl.db
@@ -1,0 +1,36 @@
+########################################################################
+# Control and Status Register [0]
+
+record(mbboDirect, "$(P)$(R)RxEnbl-SP") {
+  field(DESC, "Each bit sets Rx OUT status")
+  field(NOBT, "8")
+  field(ASG, "Interlock")
+  field(FLNK, "$(P)$(R)RxEnblVerify PP")
+}
+
+record(longout, "$(P)$(R)RxEnblMax-Cte") {
+  field(ASG, "Reserved")
+  field(PINI, YES)
+  field(VAL, 4)
+}
+
+record(calcout, "$(P)$(R)RxEnblVerify") {
+  field(ASG, "Reserved")
+  field(INPA, "$(P)$(R)RxEnbl-SP.B0")
+  field(INPB, "$(P)$(R)RxEnbl-SP.B1")
+  field(INPC, "$(P)$(R)RxEnbl-SP.B2")
+  field(INPD, "$(P)$(R)RxEnbl-SP.B3")
+  field(INPE, "$(P)$(R)RxEnbl-SP.B4")
+  field(INPF, "$(P)$(R)RxEnbl-SP.B5")
+  field(INPG, "$(P)$(R)RxEnbl-SP.B6")
+  field(INPH, "$(P)$(R)RxEnbl-SP.B7")
+  field(INPI, "$(P)$(R)RxEnbl-SP.VAL")
+  field(INPJ, "$(P)$(R)RxEnblMax-Cte.VAL")
+
+  field(CALC, "(A+B+C+D+E+F+G+H)<=J")
+  field(DOPT, "Use OCAL")
+  field(OOPT, "When Non-zero")
+
+  field(OCAL, "I")
+  field(OUT, "$(P)$(R)RxEnblHw-SP PP")
+}

--- a/timingApp/Db/fout.db
+++ b/timingApp/Db/fout.db
@@ -11,11 +11,12 @@ record(stringout, "$(P)$(R)IPPort-Mon"){
 ########################################################################
 # Control and Status Register [0]
 
-record(mbboDirect, "$(P)$(R)RxEnbl-SP") {
-  field(DESC, "Each bit sets Rx OUT status")
+record(mbboDirect, "$(P)$(R)RxEnblHw-SP") {
+  field(DESC, "RxEnbl actually written to hw.")
+  field(NOBT, "8")
   field(DTYP, "stream")
   field(OUT, "@timing.proto fout_ctrl_set($(P),$(R)) $(PORT)")
-  field(ASG, "Interlock")
+  field(ASG, "Reserved")
 }
 
 record(mbbiDirect, "$(P)$(R)RxEnbl-RB") {

--- a/timingApp/Db/timing.proto
+++ b/timingApp/Db/timing.proto
@@ -18,7 +18,7 @@ fout_ctrl_get{
 }
 
 fout_ctrl_set{
-  out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_ctrl_set)r%(\$1\$2RxLockedLtcRst-Cmd).1r\x00\x00%(\$1\$2RxEnbl-SP).1r\x00\x00\x00\x00\x00\x00\x00%(\$1\$2DevEnbl-Sel.RVAL)r";
+  out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_ctrl_set)r%(\$1\$2RxLockedLtcRst-Cmd).1r\x00\x00%(\$1\$2RxEnblHw-SP).1r\x00\x00\x00\x00\x00\x00\x00%(\$1\$2DevEnbl-Sel.RVAL)r";
   fout_ctrl_get;
 }
 
@@ -70,12 +70,12 @@ evg_ctrl_get {
 }
 
 evg_ctrl_seq_en_set{
-    out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_ctrl_set).1r\x00\x00\x00%(\$1\$2RxEnbl-SP).1r\x00\x00\x00\x00\x00\x00\x00%(\$1\$2\$3).1r";
+    out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_ctrl_set).1r\x00\x00\x00%(\$1\$2RxEnblHw-SP).1r\x00\x00\x00\x00\x00\x00\x00%(\$1\$2\$3).1r";
     evg_ctrl_get;
 }
 
 evg_ctrl_set{
-    out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_ctrl_set).1r%(\$1\$2RxLockedLtcRst-Cmd).1r\x00\x00%(\$1\$2RxEnbl-SP).1r\x00\x00\x00\x00\x00\x00\x00%(\$1\$2SeqEnblDevEnblCalc).1r";
+    out "\x02\x00\x00\x00\x00\x00\x0D%(\$1\$2cmd_ctrl_set).1r%(\$1\$2RxLockedLtcRst-Cmd).1r\x00\x00%(\$1\$2RxEnblHw-SP).1r\x00\x00\x00\x00\x00\x00\x00%(\$1\$2SeqEnblDevEnblCalc).1r";
     evg_ctrl_get;
 }
 


### PR DESCRIPTION
The new hardware version still can't actually safely handle more than 4 enabled Rx paths. This limitation used to be implemented in the gateware less transparently, but it was removed.