### PR TITLE
Provide a better interface to logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,4 +14,4 @@ services:
         REPONAME: sinap-timing-epics-ioc
         RUNDIR: /opt/sinap-timing-epics-ioc/iocBoot/ioctiming
         ENTRYPOINT: ./runProcServ.sh
-        RUNTIME_PACKAGES: python3-minimal libpython3-stdlib ca-certificates
+        RUNTIME_PACKAGES: python3-minimal libpython3-stdlib ca-certificates libevent-pthreads-2.1-7

--- a/timingApp/Db/event_log.db
+++ b/timingApp/Db/event_log.db
@@ -267,13 +267,26 @@ record(calcout, "$(P)$(R)pullAgain"){
   field(FLNK, "$(P)$(R)LOGCTRL")
 }
 
+record(bo, "$(P)$(R)StopSoftLog-Sel"){
+  field(DESC, "stop soft logging")
+  field(ONAM, "Running")
+  field(ZNAM, "Stopped")
+  field(OUT, "$(P)$(R)StopSoftLog-Sts PP")
+}
+record(bi, "$(P)$(R)StopSoftLog-Sts"){
+  field(DESC, "stop soft logging")
+  field(ONAM, "Running")
+  field(ZNAM, "Stopped")
+}
+
 record(calcout, "$(P)$(R)PeriodicPull"){
   field(ASG, "Reserved")
   field(DESC, "Periodic pull of timestamps")
   field(SCAN, "2 second")
   field(INPA, "$(P)$(R)whileNotEmpty.VAL")
   field(INPB, "$(P)$(R)EMPTY")
-  field(CALC, "(A = 0) && (B = 0)")
+  field(INPC, "$(P)$(R)StopSoftLog-Sts")
+  field(CALC, "(A = 0) && (B = 0) && (C = 0)")
   field(VAL, "0")
   field(OOPT, "When Non-zero")
   field(OUT, "$(P)$(R)whileNotEmpty.PROC")

--- a/timingApp/Db/event_log.db
+++ b/timingApp/Db/event_log.db
@@ -190,7 +190,7 @@ record(compress, "$(P)$(R)UTCbuffer"){
   field(DESC, "UTC circular buffer")
   field(EGU, "seconds")
   field(ALG, "Circular Buffer")
-  field(NSAM, "1000")
+  field(NSAM, "20000")
   field(INP, "$(P)$(R)LOGUTC")
   field(FLNK, "$(P)$(R)SUBSECbuffer")
 }
@@ -200,7 +200,7 @@ record(compress, "$(P)$(R)SUBSECbuffer"){
   field(DESC, "SUBSEC circular buffer")
   field(EGU, "evt_T")
   field(ALG, "Circular Buffer")
-  field(NSAM, "1000")
+  field(NSAM, "20000")
   field(INP, "$(P)$(R)LOGSUBSEC")
   field(FLNK, "$(P)$(R)TSbuffer")
 }
@@ -224,7 +224,7 @@ record(compress, "$(P)$(R)TSbuffer"){
   field(DESC, "TS circular buffer (us precision)")
   field(EGU, "second")
   field(ALG, "Circular Buffer")
-  field(NSAM, "1000")
+  field(NSAM, "20000")
   field(INP, "$(P)$(R)LOGTS")
   field(FLNK, "$(P)$(R)EVENTbuffer")
   info(Q:group, {
@@ -239,7 +239,7 @@ record(compress, "$(P)$(R)EVENTbuffer"){
   field(ASG, "Reserved")
   field(DESC, "Event circular buffer")
   field(ALG, "Circular Buffer")
-  field(NSAM, "1000")
+  field(NSAM, "20000")
   field(INP, "$(P)$(R)LOGEVENT")
   field(FLNK, "$(P)$(R)LOGSOFTCNT")
   info(Q:group, {

--- a/timingApp/Db/event_log.db
+++ b/timingApp/Db/event_log.db
@@ -260,30 +260,27 @@ record(calcout, "$(P)$(R)rstSoftBuffCalc"){
   field(OUT, "$(P)$(R)rstSoftBuffSeq.PROC")
 }
 
-record(sseq, "$(P)$(R)rstSoftBuffSeq"){
+record(seq, "$(P)$(R)rstSoftBuffSeq"){
   field(ASG, "Reserved")
   field(DESC, "Reset software buffers sequence")
   field(SELM, "All")
+  # We reset and process the buffers. This causes them to pull the latest value from hardware (possibly -1).
+  # Then we reset them again, so they are emptied before the monitor is posted.
   field(DO1, "1")
   field(DO2, "1")
   field(DO3, "1")
-  field(DO4, "0")
+  field(DO4, "1")
   field(DO5, "1")
   field(DO6, "1")
-  field(DO7, "1")
-  field(LNK1, "$(P)$(R)UTCbuffer.RES PP")	# Reset and process UTC buffer. It will pull a -1 when processed.
-  field(LNK2, "$(P)$(R)SUBSECbuffer.RES PP")	# Reset and process SUBSEC buffer. It will pull a -1 when processed.
-  field(LNK3, "$(P)$(R)EVENTbuffer.RES PP")	# Reset and process EVENT buffer. It will pull a -1 when processed.
-  field(LNK4, "$(P)$(R)LOGSOFTCNT")		# Zero soft log count
-  field(LNK5, "$(P)$(R)UTCbuffer.RES")	# Reset buffer again, and do not process, to remove -1.
-  field(LNK6, "$(P)$(R)SUBSECbuffer.RES")	# Reset buffer again, and do not process, to remove -1.
-  field(LNK7, "$(P)$(R)EVENTbuffer.RES")	# Reset buffer again, and do not process, to remove -1.
-  field(WAIT1, "Wait")
-  field(WAIT2, "Wait")
-  field(WAIT3, "Wait")
-  field(WAIT4, "Wait")
-  field(WAIT5, "Wait")
-  field(WAIT6, "Wait")
+  field(LNK1, "$(P)$(R)UTCbuffer.RES PP")
+  field(LNK2, "$(P)$(R)SUBSECbuffer.RES PP")
+  field(LNK3, "$(P)$(R)EVENTbuffer.RES PP")
+  field(LNK4, "$(P)$(R)UTCbuffer.RES")
+  field(LNK5, "$(P)$(R)SUBSECbuffer.RES")
+  field(LNK6, "$(P)$(R)EVENTbuffer.RES")
+  # Zero soft log count
+  field(DO7, "-1")
+  field(LNK7, "$(P)$(R)LOGSOFTCNT PP")
 }
 
 record(longout, "$(P)$(R)cmd_log_get"){

--- a/timingApp/Db/event_log.db
+++ b/timingApp/Db/event_log.db
@@ -171,7 +171,18 @@ record(longout, "$(P)$(R)readAndUpdate"){
   field(DTYP, "stream")
   field(OUT, "@timing.proto evgre_log_get($(P),$(R)) $(PORT)")
   field(PRIO, "HIGH")
+  field(FLNK, "$(P)$(R)LOGTS")
+}
+
+record(calc, "$(P)$(R)LOGTS"){
+  field(DESC, "timestamp calculated from log")
+  field(INPA, "$(P)$(R)LOGUTC")
+  field(INPB, "$(P)$(R)LOGSUBSEC")
+  field(INPC, "$(P)$(R)FPGAClk-Cte")
+  field(CALC, "A + B / C")
+  field(EGU, "seconds")
   field(FLNK, "$(P)$(R)UTCbuffer")
+  field(PREC, 6)
 }
 
 record(compress, "$(P)$(R)UTCbuffer"){
@@ -191,7 +202,18 @@ record(compress, "$(P)$(R)SUBSECbuffer"){
   field(ALG, "Circular Buffer")
   field(NSAM, "1000")
   field(INP, "$(P)$(R)LOGSUBSEC")
+  field(FLNK, "$(P)$(R)TSbuffer")
+}
+
+record(compress, "$(P)$(R)TSbuffer"){
+  field(ASG, "Reserved")
+  field(DESC, "TS circular buffer (us precision)")
+  field(EGU, "second")
+  field(ALG, "Circular Buffer")
+  field(NSAM, "1000")
+  field(INP, "$(P)$(R)LOGTS")
   field(FLNK, "$(P)$(R)EVENTbuffer")
+  field(PREC, 6)
 }
 
 record(compress, "$(P)$(R)EVENTbuffer"){
@@ -272,15 +294,19 @@ record(seq, "$(P)$(R)rstSoftBuffSeq"){
   field(DO4, "1")
   field(DO5, "1")
   field(DO6, "1")
+  field(DO7, "1")
+  field(DO8, "1")
   field(LNK1, "$(P)$(R)UTCbuffer.RES PP")
   field(LNK2, "$(P)$(R)SUBSECbuffer.RES PP")
-  field(LNK3, "$(P)$(R)EVENTbuffer.RES PP")
-  field(LNK4, "$(P)$(R)UTCbuffer.RES")
-  field(LNK5, "$(P)$(R)SUBSECbuffer.RES")
-  field(LNK6, "$(P)$(R)EVENTbuffer.RES")
+  field(LNK3, "$(P)$(R)TSbuffer.RES PP")
+  field(LNK4, "$(P)$(R)EVENTbuffer.RES PP")
+  field(LNK5, "$(P)$(R)UTCbuffer.RES")
+  field(LNK6, "$(P)$(R)SUBSECbuffer.RES")
+  field(LNK7, "$(P)$(R)TSbuffer.RES")
+  field(LNK8, "$(P)$(R)EVENTbuffer.RES")
   # Zero soft log count
-  field(DO7, "-1")
-  field(LNK7, "$(P)$(R)LOGSOFTCNT PP")
+  field(DO9, "-1")
+  field(LNK9, "$(P)$(R)LOGSOFTCNT PP")
 }
 
 record(longout, "$(P)$(R)cmd_log_get"){

--- a/timingApp/Db/event_log.db
+++ b/timingApp/Db/event_log.db
@@ -205,6 +205,20 @@ record(compress, "$(P)$(R)SUBSECbuffer"){
   field(FLNK, "$(P)$(R)TSbuffer")
 }
 
+record(aai, "$(P)$(R)bufferLABELS"){
+  field(ASG, "Reserved")
+  field(NELM, 2)
+  field(FTVL, "STRING")
+  field(INP, {const:["Timestamp", "Event"]})
+  info(Q:group, {
+    "$(P)$(R)EventTable-Mon": {
+      +id: "epics:nt/NTTable:1.0",
+      labels: {+type: "plain", +channel: "VAL"},
+      descriptor: {+type: "const", +const: "timestamp and event table (us precision)"}
+    }
+  })
+}
+
 record(compress, "$(P)$(R)TSbuffer"){
   field(ASG, "Reserved")
   field(DESC, "TS circular buffer (us precision)")
@@ -213,6 +227,11 @@ record(compress, "$(P)$(R)TSbuffer"){
   field(NSAM, "1000")
   field(INP, "$(P)$(R)LOGTS")
   field(FLNK, "$(P)$(R)EVENTbuffer")
+  info(Q:group, {
+    "$(P)$(R)EventTable-Mon": {
+      "value.A": {+type: "plain", +channel: "VAL"}
+    }
+  })
   field(PREC, 6)
 }
 
@@ -223,6 +242,11 @@ record(compress, "$(P)$(R)EVENTbuffer"){
   field(NSAM, "1000")
   field(INP, "$(P)$(R)LOGEVENT")
   field(FLNK, "$(P)$(R)LOGSOFTCNT")
+  info(Q:group, {
+    "$(P)$(R)EventTable-Mon": {
+      "value.B": {+type: "plain", +channel: "VAL", +trigger: "*"}
+    }
+  })
 }
 
 record(calc, "$(P)$(R)LOGSOFTCNT"){
@@ -307,6 +331,11 @@ record(seq, "$(P)$(R)rstSoftBuffSeq"){
   # Zero soft log count
   field(DO9, "-1")
   field(LNK9, "$(P)$(R)LOGSOFTCNT PP")
+  info(Q:group, {
+    "$(P)$(R)EventTable-Mon": {
+      "": {+type: "meta", +channel: "VAL", +trigger: "*"}
+    }
+  })
 }
 
 record(longout, "$(P)$(R)cmd_log_get"){

--- a/timingApp/src/Makefile
+++ b/timingApp/src/Makefile
@@ -115,6 +115,11 @@ timing_LIBS += stream
 timing_LIBS += autosave
 timing_LIBS += caPutLog
 
+ifneq ($(PVXS),)
+    timing_DBD += pvxsIoc.dbd
+    timing_LIBS += pvxsIoc pvxs
+endif
+
 # Finally link to the EPICS Base libraries
 timing_LIBS += $(EPICS_BASE_IOC_LIBS)
 


### PR DESCRIPTION
Implements some of the improvements discussed in https://github.com/lnls-sirius/hla/pull/720

Also adds an NTTable to provide atomic access to the timestamp and event waveforms.

```
erico.rolim@s-gie01-l:~$ pvinfo DE-23RaBPM:TI-EVG:EventTable-Mon
DE-23RaBPM:TI-EVG:EventTable-Mon
Server: 10.20.26.163:5075
Type:
    epics:nt/NTTable:1.0
        structure record
            structure _options
                int queueSize
                boolean atomic
        string[] labels
        structure value
            double[] A
            double[] B
 
erico.rolim@s-gie01-l:~$ pvmonitor DE-23RaBPM:TI-EVG:EventTable-Mon
DE-23RaBPM:TI-EVG:EventTable-Mon
  Timestamp Event
1.73161e+09   118
1.73194e+09   118
1.73194e+09   118
```