### PR TITLE
Fix auto-log parameter strings

### DIFF
--- a/timingApp/Db/autosave_eve.req
+++ b/timingApp/Db/autosave_eve.req
@@ -240,3 +240,4 @@ $(P)$(R)OTP22RegAByte3
 $(P)$(R)OTP23RegAByte3
 $(P)$(R)FPGAClk-Cte
 $(P)$(R)FPGAClk-Cte.INP
+$(P)$(R)StopSoftLog-Sel

--- a/timingApp/Db/autosave_evg.req
+++ b/timingApp/Db/autosave_evg.req
@@ -310,3 +310,4 @@ $(P)$(R)BucketList-SP
 $(P)$(R)FPGAClk-Cte
 $(P)$(R)RFRef-Mon
 $(P)$(R)RFRef-Mon.INP
+$(P)$(R)StopSoftLog-Sel

--- a/timingApp/Db/autosave_evr.req
+++ b/timingApp/Db/autosave_evr.req
@@ -240,3 +240,4 @@ $(P)$(R)OTP22RegAByte3
 $(P)$(R)OTP23RegAByte3
 $(P)$(R)FPGAClk-Cte
 $(P)$(R)FPGAClk-Cte.INP
+$(P)$(R)StopSoftLog-Sel

--- a/timingApp/Db/event_log.db
+++ b/timingApp/Db/event_log.db
@@ -269,14 +269,14 @@ record(calcout, "$(P)$(R)pullAgain"){
 
 record(bo, "$(P)$(R)StopSoftLog-Sel"){
   field(DESC, "stop soft logging")
-  field(ONAM, "Running")
-  field(ZNAM, "Stopped")
+  field(ZNAM, "Running")
+  field(ONAM, "Stopped")
   field(OUT, "$(P)$(R)StopSoftLog-Sts PP")
 }
 record(bi, "$(P)$(R)StopSoftLog-Sts"){
   field(DESC, "stop soft logging")
-  field(ONAM, "Running")
-  field(ZNAM, "Stopped")
+  field(ZNAM, "Running")
+  field(ONAM, "Stopped")
 }
 
 record(calcout, "$(P)$(R)PeriodicPull"){


### PR DESCRIPTION
Log auto-pull parameter strings were inverted. This should solve https://github.com/lnls-dig/sinap-timing-epics-ioc/issues/49.

StopSoftLog-{Sel/Sts} were add to EVE, EVR and EVG autosave.

It was tested in the EVG testbench.


